### PR TITLE
fix(images): serving images from public/images/projects this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,10 +133,13 @@ If the issue you are working on is an approved request for adding a new project 
 
 5. Double-check that the JSON syntax is correct to avoid breaking the data structure.
 
-6. Include any relevant tests to verify the new project entry if applicable.
+6. Add a featured image 
+- open your webpage in a browser
+- press on `F11` so that the browser contents takes full width
+- take a full width `16x9` aspect ratio screenshot using any screenshot tool
+- add the image to the root `public/images/projects` folder
 
-* Images that are served from the analog endpoint are currently hosted in the repo called `images` under the `projects` folder. If the image of the project doesn't load verify the path and that the image is present in that repo. This is a temporary solution since the images from the regular location - `assets/images/projects` are not loading.
-[Issue #17](https://github.com/TechShowcase/builtwithanalog/issues/17)
+7. Include any relevant tests to verify the new project entry if applicable.
 
 Following these steps will ensure that new projects are added correctly and maintain the integrity of the data used by the application.
 


### PR DESCRIPTION
## This PR Closes Issue 
closes #17 

## Description
- after implementing the new file structure including a `public` folder at root level images can be served from the repo

## What type of PR is this? (check all applicable)

- [ ] 🅰️ Project Submission
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings
[Attach screenshots or recordings if applicable]

## Steps to QA

## Added to documentation?
- [ ] 📜 README.md
- [x] 📜 CONTRIBUTING.md
- [ ] 🙅 no documentation needed

## [Optional] Post-deployment tasks
[Specify any post-deployment tasks that need to be performed]

## [Optional] What gif best describes this PR or how it makes you feel? 
[Embed gif or describe the feeling in plain text]
